### PR TITLE
Add support for emscripten

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: rust
 dist: trusty
-sudo: false
+sudo: required
+
+services:
+  - docker
 
 env:
   global:
@@ -90,6 +93,7 @@ matrix:
         apt:
           packages:
             - gcc-mingw-w64-x86-64
+    - env: TARGET=asmjs-unknown-emscripten CMD=run DOCKER=tomaka/rustc-emscripten
 
     - rust: beta
       env: TARGET=x86_64-unknown-linux-gnu NO_ADD=1 CMD=run
@@ -100,7 +104,11 @@ install:
   - if [ -z "$NO_ADD" ]; then rustup target add $TARGET; fi
 
 script:
-  - cargo "${CMD:-build}" --manifest-path testcrate/Cargo.toml --target $TARGET --bin test
+  - if [ -z "$DOCKER" ]; then
+      cargo "${CMD:-build}" --manifest-path testcrate/Cargo.toml --target $TARGET --bin test
+    else
+      docker run --rm -it -v `pwd`:/usr/code -w /usr/code $DOCKER cargo "${CMD:-build}" --manifest-path testcrate/Cargo.toml --target $TARGET --bin test
+    fi
 
 notifications:
   email:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,13 +124,6 @@ impl Build {
             configure.arg("no-shared");
         }
 
-        if target.contains("emscripten") || target == "wasm32-unknown-unknown" {
-            // Don't use stdio on emscripten, as it makes little sense and triggers compilation
-            // errors
-            configure.arg("no-stdio");
-            configure.arg("no-threads");
-        }
-
         let os = match target {
             "aarch64-linux-android" => "android64-aarch64",
             "aarch64-unknown-linux-gnu" => "linux-aarch64",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,9 @@ impl Build {
             // No need to build tests, we won't run them anyway
             .arg("no-unit-test")
 
+            // No need for CLI tools
+            .arg("no-ui")
+
             // Nothing related to zlib please
             .arg("no-comp")
             .arg("no-zlib")
@@ -121,6 +124,13 @@ impl Build {
             configure.arg("no-shared");
         }
 
+        if target.contains("emscripten") {
+            // Don't use stdio on emscripten, as it makes little sense and triggers compilation
+            // errors
+            configure.arg("no-stdio");
+            configure.arg("no-threads");
+        }
+
         let os = match target {
             "aarch64-linux-android" => "android64-aarch64",
             "aarch64-unknown-linux-gnu" => "linux-aarch64",
@@ -128,6 +138,7 @@ impl Build {
             "arm-unknown-linux-gnueabi" => "linux-armv4",
             "arm-unknown-linux-gnueabihf" => "linux-armv4",
             "armv7-unknown-linux-gnueabihf" => "linux-armv4",
+            "asmjs-unknown-emscripten" => "gcc",
             "i686-apple-darwin" => "darwin-i386-cc",
             "i686-linux-android" => "android-x86",
             "i686-pc-windows-gnu" => "mingw",
@@ -151,6 +162,7 @@ impl Build {
             "x86_64-unknown-linux-gnu" => "linux-x86_64",
             "x86_64-unknown-linux-musl" => "linux-x86_64",
             "x86_64-unknown-netbsd" => "BSD-x86_64",
+            "wasm32-unknown-emscripten" => "gcc",
             _ => panic!("don't know how to configure OpenSSL for {}", target),
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ impl Build {
             configure.arg("no-shared");
         }
 
-        if target.contains("emscripten") {
+        if target.contains("emscripten") || target == "wasm32-unknown-unknown" {
             // Don't use stdio on emscripten, as it makes little sense and triggers compilation
             // errors
             configure.arg("no-stdio");
@@ -163,6 +163,7 @@ impl Build {
             "x86_64-unknown-linux-musl" => "linux-x86_64",
             "x86_64-unknown-netbsd" => "BSD-x86_64",
             "wasm32-unknown-emscripten" => "gcc",
+            "wasm32-unknown-unknown" => "gcc",
             _ => panic!("don't know how to configure OpenSSL for {}", target),
         };
 


### PR DESCRIPTION
`wasm32-unknown-unknown` is a bit harder, so I focused on emscripten first.

`emcc` is similar to `gcc`, so we can configure OpenSSL for `gcc` and it works.
However if we simply do that, we get linking errors when building the `openssl` executable because some symbols are defined twice. I have no idea what that happens.

The easiest way to disable building the `openssl` executable if to use `no-stdio`, so that's what I'm doing.

Tests unfortunately fail because of out-of-memory issues, but the ones which don't need a lot of memory all pass.
I didn't add any CI test because it's quite hard to test for emscripten on travis (building emscripten :-/). It should be doable with circle-ci if you think we should add CI.