### PR TITLE
Add support for armv7-unknown-linux-musleabihf target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ impl Build {
             "arm-unknown-linux-gnueabi" => "linux-armv4",
             "arm-unknown-linux-gnueabihf" => "linux-armv4",
             "armv7-unknown-linux-gnueabihf" => "linux-armv4",
+            "armv7-unknown-linux-musleabihf" => "linux-armv4",
             "asmjs-unknown-emscripten" => "gcc",
             "i686-apple-darwin" => "darwin-i386-cc",
             "i686-linux-android" => "android-x86",


### PR DESCRIPTION
Hi. I am cross compiling from x86_64-unknown-linux-gnu -> armv7-unknown-linux-musleabihf. I found I needed this small addition for things to work.