### PR TITLE
FreeBSD also uses BSD make, so need to call gmake instead

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ impl Build {
     fn cmd_make(&self) -> Command {
         match &self.host.as_ref().expect("HOST dir not set")[..] {
             "x86_64-unknown-dragonfly" => Command::new("gmake"),
+            "x86_64-unknown-freebsd" => Command::new("gmake"),
             _ => Command::new("make"),
         }
     }


### PR DESCRIPTION
very much like recent DragonflyBSD changes, on FreeBSD make is BSD make, calling gmake instead