### PR TITLE
cross compilation on windows for mips

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,8 @@ impl Build {
         configure.arg("./Configure");
         if target.contains("pc-windows-gnu") {
             configure.arg(&format!("--prefix={}", sanitize_sh(&install_dir)));
-        } else if target.contains("mipsel-unknown-linux-gnu") {
+        } else if host.contains("pc-windows-gnu")
+            && target.starts_with("mips") && target.contains("gnu") {
             configure.arg(&format!("--prefix={}", sanitize_sh(&install_dir)));
         } else {
             configure.arg(&format!("--prefix={}", install_dir.display()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,8 @@ impl Build {
         configure.arg("./Configure");
         if target.contains("pc-windows-gnu") {
             configure.arg(&format!("--prefix={}", sanitize_sh(&install_dir)));
+        } else if target.contains("mipsel-unknown-linux-gnu") {
+            configure.arg(&format!("--prefix={}", sanitize_sh(&install_dir)));
         } else {
             configure.arg(&format!("--prefix={}", install_dir.display()));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,10 +79,7 @@ impl Build {
 
         let mut configure = Command::new("perl");
         configure.arg("./Configure");
-        if target.contains("pc-windows-gnu") {
-            configure.arg(&format!("--prefix={}", sanitize_sh(&install_dir)));
-        } else if host.contains("pc-windows-gnu")
-            && target.starts_with("mips") && target.contains("gnu") {
+        if host.contains("pc-windows-gnu") {
             configure.arg(&format!("--prefix={}", sanitize_sh(&install_dir)));
         } else {
             configure.arg(&format!("--prefix={}", install_dir.display()));


### PR DESCRIPTION
Just in my case, this can ease my life:)

Install paths are generated that are windows escaped (C:\\for\\the\\way)
When cross compiling to my **mips** target i have GNU-tools working and c:/for/the/way is the way to go.

Use case of Doom: 
Cross compilation for an embedded target and to have the ability to switch between targets. 
Main development happens on the HOST and also testing, playground, debugging.

My solution so far is: 
cfg openssl-sys for linux vendor featured, patch crates-io and have this path local.

```
[target.'cfg(target_os = "linux")'.dependencies]
openssl-sys = { version = "0.9.12", features = ["vendored"] }

[patch.crates-io]
openssl-src = { path = './dependencies/openssl-src-111.2.1+1.1.1b' }

```
full on IDE:
When you have to fiddle with configuration files between switching target/host compilation ... that's annoying. And not our fault. Maybe cargo/xargo shows an easy way in the future for this.

mhghmhmm, Alex: The build triplet 'mipsel-unknown-linux-gnu' is my local egoistic concern and maybe my if clauses are wrong, boss:)