### PR TITLE
Add aarch64-unknown-linux-musl target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@ impl Build {
             // out and say it's linux and hope it works.
             "aarch64-linux-android" => "linux-aarch64",
             "aarch64-unknown-linux-gnu" => "linux-aarch64",
+            "aarch64-unknown-linux-musl" => "linux-aarch64",
             "aarch64-pc-windows-msvc" => "VC-WIN64-ARM",
             "arm-linux-androideabi" => "linux-armv4",
             "armv7-linux-androideabi" => "linux-armv4",


### PR DESCRIPTION
This adds support for Aarch64 builds with musl libc.