### PR TITLE
add aarch64-apple-ios target support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,6 @@ impl Build {
         // loading system certificates so only disable it on Android.
         if target.contains("android") {
             configure.arg("no-stdio");
-            //configure.arg("no-ui-console");
         }
 
         if target.contains("msvc") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ impl Build {
         // loading system certificates so only disable it on Android.
         if target.contains("android") {
             configure.arg("no-stdio");
+            //configure.arg("no-ui-console");
         }
 
         if target.contains("msvc") {
@@ -185,6 +186,8 @@ impl Build {
             _ => panic!("don't know how to configure OpenSSL for {}", target),
         };
 
+        let mut ios_isysroot: std::option::Option<String> = None;
+
         configure.arg(os);
 
         // If we're not on MSVC we configure cross compilers and cross tools and
@@ -211,12 +214,39 @@ impl Build {
 
             // Make sure we pass extra flags like `-ffunction-sections` and
             // other things like ARM codegen flags.
+            let mut skip_next = false;
+            let mut is_isysroot = false;
             for arg in compiler.args() {
                 // For whatever reason `-static` on MUSL seems to cause
                 // issues...
                 if target.contains("musl") && arg == "-static" {
                     continue
                 }
+
+                // cargo-lipo specifies this but OpenSSL complains
+                if target.contains("apple-ios") {
+                    if arg == "-arch" {
+                        skip_next = true;
+                        continue
+                    }
+
+                    if arg == "-isysroot" {
+                        is_isysroot = true;
+                        continue
+                    }
+
+                    if is_isysroot {
+                        is_isysroot = false;
+                        ios_isysroot = Some(arg.to_str().unwrap().to_string());
+                        continue
+                    }
+                }
+
+                if skip_next {
+                    skip_next = false;
+                    continue
+                }
+
                 configure.arg(arg);
             }
 
@@ -291,6 +321,13 @@ impl Build {
                     build.env("MAKEFLAGS", s);
                 }
             }
+
+            if let Some(ref isysr) = ios_isysroot {
+                let components: Vec<&str> = isysr.split("/SDKs/").collect();
+                build.env("CROSS_TOP", components[0]);
+                build.env("CROSS_SDK", components[1]);
+            }
+
             self.run_command(build, "building OpenSSL");
 
             let mut install = self.cmd_make();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,7 @@ impl Build {
             "x86_64-unknown-netbsd" => "BSD-x86_64",
             "wasm32-unknown-emscripten" => "gcc",
             "wasm32-unknown-unknown" => "gcc",
+            "aarch64-apple-ios" => "ios64-cross",
             _ => panic!("don't know how to configure OpenSSL for {}", target),
         };
 


### PR DESCRIPTION
I'm not sure how to test this, please let me know if you have a tip on how to get started!

Hacks:
- Remove `-arch xxx` arg supplied by `cargo-lipo`; OpenSSL already adds it and complains
- Remove and split up `-isysroot xxx` arg supplied by `cargo-lipo`; OpenSSL already adds it and complains, but needs parts of it during *build* phase