### PR TITLE
Fix cross compilation when `CROSS_COMPILE` env is set

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,11 @@ impl Build {
             configure.env("CC", compiler.path());
             let path = compiler.path().to_str().unwrap();
 
+            // Both `cc::Build` and `./Configure` take into account
+            // `CROSS_COMPILE` environment variable. So to avoid double
+            // prefix, we unset `CROSS_COMPILE` for `./Configure`.
+            configure.env_remove("CROSS_COMPILE");
+
             // Infer ar/ranlib tools from cross compilers if the it looks like
             // we're doing something like `foo-gcc` route that to `foo-ranlib`
             // as well.


### PR DESCRIPTION
When `CROSS_COMPILE` is set `cc::Build` is using it to generate compiler command. However `./Configure` of OpenSSL is using it again which has as a result the environment variable to the prepended twice.

For example `CROSS_COMPILE=arm-none-linux-gnueabi` will result to
`arm-none-linux-gnueabiarm-none-linux-gnueabi-gcc`