### PR TITLE
only build necessary target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,12 +310,12 @@ impl Build {
         if target.contains("msvc") {
             let mut build =
                 cc::windows_registry::find(target, "nmake.exe").expect("failed to find nmake");
-            build.current_dir(&inner_dir);
+            build.arg("build_libs").current_dir(&inner_dir);
             self.run_command(build, "building OpenSSL");
 
             let mut install =
                 cc::windows_registry::find(target, "nmake.exe").expect("failed to find nmake");
-            install.arg("install_sw").current_dir(&inner_dir);
+            install.arg("install_dev").current_dir(&inner_dir);
             self.run_command(install, "installing OpenSSL");
         } else {
             let mut depend = self.cmd_make();
@@ -323,7 +323,7 @@ impl Build {
             self.run_command(depend, "building OpenSSL dependencies");
 
             let mut build = self.cmd_make();
-            build.current_dir(&inner_dir);
+            build.arg("build_libs").current_dir(&inner_dir);
             if !cfg!(windows) {
                 if let Some(s) = env::var_os("CARGO_MAKEFLAGS") {
                     build.env("MAKEFLAGS", s);
@@ -339,7 +339,7 @@ impl Build {
             self.run_command(build, "building OpenSSL");
 
             let mut install = self.cmd_make();
-            install.arg("install_sw").current_dir(&inner_dir);
+            install.arg("install_dev").current_dir(&inner_dir);
             self.run_command(install, "installing OpenSSL");
         }
 


### PR DESCRIPTION
When building it for ppcle64, it fails to build tests:
```
test/libtestutil.a(tests.o): In function `test_time_t_eq':
/workspace/openssl-src-rs/target/debug/build/testcrate-0895561f72afc32c/out/openssl-build/build/src/test/testutil/tests.c:443: undefined reference to `ASN1_TIME_compare'
test/libtestutil.a(tests.o): In function `test_time_t_ne':
/workspace/openssl-src-rs/target/debug/build/testcrate-test0895561f72afc32c//outlibtestutil.a/(openssltests.o): -In buildfunction/ `buildtest_time_t_eq/':
src//workspace//openssl-testutilsrc-rs//targettests.c/:debug444/:build/ testcrate-0895561f72afc32c/undefinedout/ openssl-reference buildto/build/ src/`test/ASN1_TIME_comparetestutil/'tests.c
:443test: /undefined referencelibtestutil.a( totests.o `)ASN1_TIME_compare:'
test/libtestutil.aIn(tests.o ): functionIn  `functiontest_time_t_gt `'test_time_t_ne'::

/workspace//openssl-src-rs/targetworkspace//debug/opensslbuild/testcrate--src0895561f72afc32c-/rsout//openssl-targetbuild//build/srcdebug//test/buildtestutil/tests.c/:testcrate444:- 0895561f72afc32cundefined/ outreference /toopenssl -`buildASN1_TIME_compare/'
```

Apparently, what the crate wants are libraries and headers instead of tests or programs. So I change the build target to `build_libs` and install target to `install_dev` to get around the problem.