### PR TITLE
Add support for non-x86 archs on FreeBSD

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,7 @@ impl Build {
             // that bypasses basically everything `cc` does, so let's just cop
             // out and say it's linux and hope it works.
             "aarch64-linux-android" => "linux-aarch64",
+            "aarch64-unknown-freebsd" => "BSD-generic64",
             "aarch64-unknown-linux-gnu" => "linux-aarch64",
             "aarch64-unknown-linux-musl" => "linux-aarch64",
             "aarch64-pc-windows-msvc" => "VC-WIN64-ARM",
@@ -146,6 +147,8 @@ impl Build {
             "arm-unknown-linux-gnueabihf" => "linux-armv4",
             "arm-unknown-linux-musleabi" => "linux-armv4",
             "arm-unknown-linux-musleabihf" => "linux-armv4",
+            "armv6-unknown-freebsd" => "BSD-generic32",
+            "armv7-unknown-freebsd" => "BSD-generic32",
             "armv7-unknown-linux-gnueabihf" => "linux-armv4",
             "armv7-unknown-linux-musleabihf" => "linux-armv4",
             "asmjs-unknown-emscripten" => "gcc",
@@ -163,6 +166,7 @@ impl Build {
             "mipsel-unknown-linux-gnu" => "linux-mips32",
             "mipsel-unknown-linux-musl" => "linux-mips32",
             "powerpc-unknown-linux-gnu" => "linux-ppc",
+            "powerpc64-unknown-freebsd" => "BSD-generic64",
             "powerpc64-unknown-linux-gnu" => "linux-ppc64",
             "powerpc64le-unknown-linux-gnu" => "linux-ppc64le",
             "riscv64gc-unknown-linux-gnu" => "linux-generic64",


### PR DESCRIPTION
```
Caused by:
  process didn't exit successfully: `.../rust-bootstrap/work-aarch64/rustc-1.40.0-src/build/x86_64-unknown-freebsd/stage1-tools/release/build/openssl-sys-4b2d35028bf73953/build-script-main` (exit code: 101)
--- stdout
cargo:rustc-cfg=const_fn

--- stderr
thread 'main' panicked at 'don't know how to configure OpenSSL for aarch64-unknown-freebsd', .../rust-bootstrap/work-aarch64/rustc-1.40.0-src/vendor/openssl-src/src/lib.rs:178:18
```