### PR TITLE
Use gmake by default on all FreeBSD or DragonFlyBSD targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,11 +51,11 @@ impl Build {
     }
 
     fn cmd_make(&self) -> Command {
-        match &self.host.as_ref().expect("HOST dir not set")[..] {
-            "x86_64-unknown-dragonfly" => Command::new("gmake"),
-            "x86_64-unknown-freebsd" => Command::new("gmake"),
-            "x86_64-sun-solaris" => Command::new("gmake"),
-            _ => Command::new("make"),
+        let host = &self.host.as_ref().expect("HOST dir not set")[..];
+        if host.contains("dragonfly") || host.contains("freebsd") || host.contains("solaris") {
+            Command::new("gmake")
+        } else {
+            Command::new("make")
         }
     }
 


### PR DESCRIPTION
Or I could list all the FreeBSD targets...