### PR TITLE
Add support for illumos triple

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,11 @@ impl Build {
 
     fn cmd_make(&self) -> Command {
         let host = &self.host.as_ref().expect("HOST dir not set")[..];
-        if host.contains("dragonfly") || host.contains("freebsd") || host.contains("solaris") {
+        if host.contains("dragonfly")
+            || host.contains("freebsd")
+            || host.contains("solaris")
+            || host.contains("illumos")
+        {
             Command::new("gmake")
         } else {
             Command::new("make")
@@ -178,6 +182,7 @@ impl Build {
             "x86_64-pc-windows-msvc" => "VC-WIN64A",
             "x86_64-unknown-freebsd" => "BSD-x86_64",
             "x86_64-unknown-dragonfly" => "BSD-x86_64",
+            "x86_64-unknown-illumos" => "solaris64-x86_64-gcc",
             "x86_64-unknown-linux-gnu" => "linux-x86_64",
             "x86_64-unknown-linux-musl" => "linux-x86_64",
             "x86_64-unknown-netbsd" => "BSD-x86_64",


### PR DESCRIPTION
As part of the preparation for rust-lang/rust#55553, add support for the Solaris-like illumos target.