### PR TITLE
Add engine support for linux-gnu

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,13 +107,9 @@ impl Build {
             // stuff depends on, and we don't bind to any of that in any case.
             .arg("no-async");
 
-        if !target.contains("x86_64-unknown-linux-gnu") {
+        if target.contains("musl") {
             // This actually fails to compile on musl (it needs linux/version.h
-            // right now) but we don't actually need this most of the time. This
-            // is intended for super-configurable backends and whatnot
-            // apparently but the whole point of this script is to produce a
-            // "portable" implementation of OpenSSL, so shouldn't be any harm in
-            // turning this off.
+            // right now) but we don't actually need this most of the time.
             configure.arg("no-engine");
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,15 +102,19 @@ impl Build {
             // Nothing related to zlib please
             .arg("no-comp")
             .arg("no-zlib")
-            .arg("no-zlib-dynamic")
-            // MUSL doesn't implement some of the libc functions that the async
-            // stuff depends on, and we don't bind to any of that in any case.
-            .arg("no-async");
+            .arg("no-zlib-dynamic");
 
         if target.contains("musl") || target.contains("windows") {
             // This actually fails to compile on musl (it needs linux/version.h
             // right now) but we don't actually need this most of the time.
+            // API of engine.c ld fail in Windows.
             configure.arg("no-engine");
+        }
+
+        if target.contains("musl") {
+            // MUSL doesn't implement some of the libc functions that the async
+            // stuff depends on, and we don't bind to any of that in any case.
+            configure.arg("no-async");
         }
 
         // On Android it looks like not passing no-stdio may cause a build

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,11 +107,7 @@ impl Build {
             // stuff depends on, and we don't bind to any of that in any case.
             .arg("no-async");
 
-        if target.contains("musl")
-            || target.contains("apple")
-            || target.contains("android")
-            || target.contains("windows")
-        {
+        if target.contains("musl") || target.contains("android") || target.contains("windows") {
             // This actually fails to compile on musl (it needs linux/version.h
             // right now) but we don't actually need this most of the time.
             configure.arg("no-engine");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,11 @@ impl Build {
             // stuff depends on, and we don't bind to any of that in any case.
             .arg("no-async");
 
-        if target.contains("musl") {
+        if target.contains("musl")
+            || target.contains("apple")
+            || target.contains("android")
+            || target.contains("windows")
+        {
             // This actually fails to compile on musl (it needs linux/version.h
             // right now) but we don't actually need this most of the time.
             configure.arg("no-engine");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,16 +103,19 @@ impl Build {
             .arg("no-comp")
             .arg("no-zlib")
             .arg("no-zlib-dynamic")
+            // MUSL doesn't implement some of the libc functions that the async
+            // stuff depends on, and we don't bind to any of that in any case.
+            .arg("no-async");
+
+        if !target.contains("x86_64-unknown-linux-gnu") {
             // This actually fails to compile on musl (it needs linux/version.h
             // right now) but we don't actually need this most of the time. This
             // is intended for super-configurable backends and whatnot
             // apparently but the whole point of this script is to produce a
             // "portable" implementation of OpenSSL, so shouldn't be any harm in
             // turning this off.
-            .arg("no-engine")
-            // MUSL doesn't implement some of the libc functions that the async
-            // stuff depends on, and we don't bind to any of that in any case.
-            .arg("no-async");
+            configure.arg("no-engine");
+        }
 
         // On Android it looks like not passing no-stdio may cause a build
         // failure (#13), but most other platforms need it for things like

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ impl Build {
             // stuff depends on, and we don't bind to any of that in any case.
             .arg("no-async");
 
-        if target.contains("musl") || target.contains("android") || target.contains("windows") {
+        if target.contains("musl") || target.contains("windows") {
             // This actually fails to compile on musl (it needs linux/version.h
             // right now) but we don't actually need this most of the time.
             configure.arg("no-engine");


### PR DESCRIPTION
I met link error when updating in grpc-rs which is a binding lib to grpc-core. And I found openssl-src remove `engine` on no matter what platform.

Related PR: https://github.com/tikv/grpc-rs/pull/466

Signed-off-by: Xintao <hunterlxt@live.com>