### PR TITLE
add optional features for less used algorithms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,21 @@ exclude = [
   'openssl/test/*',
 ]
 
+[features]
+default = []
+# Enables compilation of some older algorithms: md2 (hash), rc5 (block cypher) and enabled use of
+# some weaker algorithms in SSL connections. These are generally not recommended for use.
+weak-crypto = []
+# Enables compilation of the Camellia symmetric key block cypher. Since hardware acceleration for
+# it is not available on most systems, this is not as used as AES.
+camellia = []
+# Enables compilation of International Data Encryption Algorithm (IDEA), a symmetric key block
+# cypher sometimes used as an AES128 alternative.
+idea = []
+# Enables compilation of SEED, a symmetric key block cypher mostly used in South Korea, but
+# otherwise not widely supported.
+seed = []
+
 [workspace]
 members = ['testcrate']
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -2,3 +2,6 @@ target=$1
 set -ex
 cargo test --manifest-path testcrate/Cargo.toml --target $1 -vv
 cargo test --manifest-path testcrate/Cargo.toml --target $1 -vv --release
+if [ "$1" = "x86_64-unknown-linux-gnu" ] ; then
+	cargo test --manifest-path testcrate/Cargo.toml --target $1 -vv --all-features
+fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,25 @@ impl Build {
             .arg("no-zlib")
             .arg("no-zlib-dynamic");
 
+        if cfg!(not(feature = "weak-crypto")) {
+            configure
+                .arg("no-md2")
+                .arg("no-rc5")
+                .arg("no-weak-ssl-ciphers");
+        }
+
+        if cfg!(not(feature = "camellia")) {
+            configure.arg("no-camellia");
+        }
+
+        if cfg!(not(feature = "idea")) {
+            configure.arg("no-idea");
+        }
+
+        if cfg!(not(feature = "seed")) {
+            configure.arg("no-seed");
+        }
+
         if target.contains("musl") || target.contains("windows") {
             // This actually fails to compile on musl (it needs linux/version.h
             // right now) but we don't actually need this most of the time.


### PR DESCRIPTION
This commit disables by default a few of the weaker cryptographical algorithms into
a "weak-crypto" feature as well as some of the less used algorithms into
their own specific features.

These algorithms are not directly exposed through the rust-openssl crate.
The compilation of these can be re-enabled by selecting the desired features.
This should slightly reduce build time and library size.

Signed-off-by: Petre Eftime <petre.eftime@gmail.com>

## Testing
I've tested this feature by building this crate with cargo, and by modifying a local rust-openssl repo to use my local clone as the source for openssl-src, and ran `cargo test --features vendored`, with and without these features specified in Cargo.toml.