### PR TITLE
Add FreeBSD powerpc64le support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,7 @@ impl Build {
             "powerpc-unknown-linux-gnu" => "linux-ppc",
             "powerpc64-unknown-freebsd" => "BSD-generic64",
             "powerpc64-unknown-linux-gnu" => "linux-ppc64",
+            "powerpc64le-unknown-freebsd" => "BSD-generic64",
             "powerpc64le-unknown-linux-gnu" => "linux-ppc64le",
             "riscv64gc-unknown-linux-gnu" => "linux-generic64",
             "s390x-unknown-linux-gnu" => "linux64-s390x",


### PR DESCRIPTION
FreeBSD PowerPC64LE is a new target.

This is needed to cross-build cargo.