### PR TITLE
i586 support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,8 @@ impl Build {
             "armv7-unknown-linux-gnueabihf" => "linux-armv4",
             "armv7-unknown-linux-musleabihf" => "linux-armv4",
             "asmjs-unknown-emscripten" => "gcc",
+            "i586-unknown-linux-gnu" => "linux-elf",
+            "i586-unknown-linux-musl" => "linux-elf",
             "i686-apple-darwin" => "darwin-i386-cc",
             "i686-linux-android" => "linux-elf",
             "i686-pc-windows-gnu" => "mingw",


### PR DESCRIPTION
I'm working on an Intel Quark which actually uses such an old instruction set.

Adding the `i586-unknown-linux-musl` target was all that was required to get a successful TLS connection with reqwest, compiled using the i586 toolchain provided by rust-embedded/cross.

I haven't explicitly tested the `i586-unknown-linux-gnu` target but I have no reason to think it won't work, as musl is usually the trickier target.