### PR TITLE
Make it compile for wasm32-wasi

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,7 @@ impl Build {
             "x86_64-sun-solaris" => "solaris64-x86_64-gcc",
             "wasm32-unknown-emscripten" => "gcc",
             "wasm32-unknown-unknown" => "gcc",
+            "wasm32-wasi" => "gcc",
             "aarch64-apple-ios" => "ios64-cross",
             "x86_64-apple-ios" => "iossimulator-xcrun",
             _ => panic!("don't know how to configure OpenSSL for {}", target),


### PR DESCRIPTION
It seems that `wasm32-unknown-unknown` and `wasm32-unknown-emscripten` are already supported. This PR adds `wasm32-wasi` to this list.
