### PR TITLE
add nasm support for msvc

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,6 +107,7 @@ jobs:
         curl -O https://www.nasm.us/pub/nasm/releasebuilds/${WINNASMVERSION}/win64/nasm-${WINNASMVERSION}-win64.zip
         unzip nasm-${WINNASMVERSION}-win64.zip
         echo "$PWD/nasm-${WINNASMVERSION}" >> $GITHUB_PATH
+        echo "OPENSSL_RUST_USE_NASM=yes" >> $GITHUB_ENV
     - name: Run tests (Windows)
       if: startsWith(matrix.os, 'windows')
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,13 +114,16 @@ jobs:
         WINNASMVERSION='2.15.05'
         curl -O https://www.nasm.us/pub/nasm/releasebuilds/${WINNASMVERSION}/win64/nasm-${WINNASMVERSION}-win64.zip
         unzip nasm-${WINNASMVERSION}-win64.zip
-        echo PATH=$PWD/nasm-${WINNASMVERSION}:$PATH >> $GITHUB_ENV
+        mv nasm-${WINNASMVERSION} nasm_win64
     - name: Set NO_NASM env var (Windows)
       if: startsWith(matrix.os, 'windows') && matrix.env_no_nasm == 'set'
       run: echo OPENSSL_RUST_NO_NASM=1 >> $GITHUB_ENV
     - name: Run tests (Windows)
       if: startsWith(matrix.os, 'windows')
       run: |
+        if [ '${{ matrix.nasm_exe }}' = 'installed' ] ; then
+        export PATH=$PWD/nasm_win64:$PATH
+        fi
         cargo test --manifest-path testcrate/Cargo.toml --target ${{ matrix.target }} -vv
         cargo test --manifest-path testcrate/Cargo.toml --target ${{ matrix.target }} --release -vv
         cargo run --release --target ${{ matrix.target }} --manifest-path testcrate/Cargo.toml --features package -vv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,30 +109,21 @@ jobs:
         cargo generate-lockfile
         ./ci/run-docker.sh ${{ matrix.target }}
     - name: Download nasm.exe (Windows)
-      if: startsWith(matrix.os, 'windows') && matrix.nasm_exe == 'installed'
+      if: matrix.nasm_exe == 'installed'
       run: |
         WINNASMVERSION='2.15.05'
         curl -O https://www.nasm.us/pub/nasm/releasebuilds/${WINNASMVERSION}/win64/nasm-${WINNASMVERSION}-win64.zip
         unzip nasm-${WINNASMVERSION}-win64.zip
-        mv nasm-${WINNASMVERSION} nasm_win64
+        echo "$PWD/nasm-${WINNASMVERSION}" >> $GITHUB_PATH
     - name: Set NO_NASM env var (Windows)
-      if: startsWith(matrix.os, 'windows') && matrix.env_no_nasm == 'set'
+      if: matrix.env_no_nasm == 'set'
       run: echo OPENSSL_RUST_NO_NASM=1 >> $GITHUB_ENV
     - name: Run tests (Windows)
       if: startsWith(matrix.os, 'windows')
       run: |
-        if [ '${{ matrix.nasm_exe }}' = 'installed' ] ; then
-        export PATH=$PWD/nasm_win64:$PATH
-        fi
         cargo test --manifest-path testcrate/Cargo.toml --target ${{ matrix.target }} -vv
         cargo test --manifest-path testcrate/Cargo.toml --target ${{ matrix.target }} --release -vv
         cargo run --release --target ${{ matrix.target }} --manifest-path testcrate/Cargo.toml --features package -vv
-    - name: Verify no-nasm option (Windows)
-      if: startsWith(matrix.os, 'windows') && matrix.env_no_nasm == 'set'
-      run: |
-        # if the nasm.exe is disabled, there should be 'no-asm' in the configure command
-        echo 'CI: In output files, there should be no-asm configured:'
-        grep 'no-asm' target/${{ matrix.target }}/*/build/*/output
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,7 @@ jobs:
         curl -O https://www.nasm.us/pub/nasm/releasebuilds/${WINNASMVERSION}/win64/nasm-${WINNASMVERSION}-win64.zip
         unzip nasm-${WINNASMVERSION}-win64.zip
         echo "$GITHUB_WORKSPACE\\nasm-${WINNASMVERSION}" >> $GITHUB_PATH
-        echo "OPENSSL_RUST_USE_NASM=yes" >> $GITHUB_ENV
+        echo "OPENSSL_RUST_USE_NASM=1" >> $GITHUB_ENV
     - name: Run tests (Windows)
       if: startsWith(matrix.os, 'windows')
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ defaults:
   run:
     shell: bash
 
+env:
+  WINNASMVERSION: 2.15.05
+
 jobs:
   test:
     name: Test
@@ -76,6 +79,15 @@ jobs:
           rust: stable-x86_64-msvc
           os: windows-latest
           crt_static: yes
+        - target: x86_64-pc-windows-msvc
+          rust: stable-x86_64-msvc
+          os: windows-latest
+          nasm_exe: installed
+        - target: x86_64-pc-windows-msvc
+          rust: stable-x86_64-msvc
+          os: windows-latest
+          nasm_exe: installed
+          env_no_nasm: set
 
     steps:
     - uses: actions/checkout@v1
@@ -90,18 +102,34 @@ jobs:
     - name: Use strawberry perl
       if: startsWith(matrix.os, 'windows')
       run: echo OPENSSL_SRC_PERL=C:/Strawberry/perl/bin/perl >> $GITHUB_ENV
-    - run: |
+    - name: Run tests (not Windows)
+      if: "!startsWith(matrix.os, 'windows')"
+      run: |
         set -e
         cargo generate-lockfile
         ./ci/run-docker.sh ${{ matrix.target }}
-      if: "!startsWith(matrix.os, 'windows')"
-      name: Run tests (not Windows)
-    - run: |
+    - name: Download nasm.exe (Windows)
+      if: startsWith(matrix.os, 'windows') && matrix.nasm_exe == 'installed'
+      run: |
+        WINNASMVERSION='2.15.05'
+        curl -O https://www.nasm.us/pub/nasm/releasebuilds/${WINNASMVERSION}/win64/nasm-${WINNASMVERSION}-win64.zip
+        unzip nasm-${WINNASMVERSION}-win64.zip
+        echo PATH=$PWD/nasm-${WINNASMVERSION}:$PATH >> $GITHUB_ENV
+    - name: Set NO_NASM env var (Windows)
+      if: startsWith(matrix.os, 'windows') && matrix.env_no_nasm == 'set'
+      run: echo OPENSSL_RUST_NO_NASM=1 >> $GITHUB_ENV
+    - name: Run tests (Windows)
+      if: startsWith(matrix.os, 'windows')
+      run: |
         cargo test --manifest-path testcrate/Cargo.toml --target ${{ matrix.target }} -vv
         cargo test --manifest-path testcrate/Cargo.toml --target ${{ matrix.target }} --release -vv
         cargo run --release --target ${{ matrix.target }} --manifest-path testcrate/Cargo.toml --features package -vv
-      if: startsWith(matrix.os, 'windows')
-      name: Run tests (Windows)
+    - name: Verify no-nasm option (Windows)
+      if: startsWith(matrix.os, 'windows') && matrix.env_no_nasm == 'set'
+      run: |
+        # if the nasm.exe is disabled, there should be 'no-asm' in the configure command
+        echo 'CI: In output files, there should be no-asm configured:'
+        grep 'no-asm' target/${{ matrix.target }}/*/build/*/output
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  WINNASMVERSION: 2.15.05
-
 jobs:
   test:
     name: Test
@@ -83,11 +80,6 @@ jobs:
           rust: stable-x86_64-msvc
           os: windows-latest
           nasm_exe: installed
-        - target: x86_64-pc-windows-msvc
-          rust: stable-x86_64-msvc
-          os: windows-latest
-          nasm_exe: installed
-          env_no_nasm: set
 
     steps:
     - uses: actions/checkout@v1
@@ -115,9 +107,6 @@ jobs:
         curl -O https://www.nasm.us/pub/nasm/releasebuilds/${WINNASMVERSION}/win64/nasm-${WINNASMVERSION}-win64.zip
         unzip nasm-${WINNASMVERSION}-win64.zip
         echo "$PWD/nasm-${WINNASMVERSION}" >> $GITHUB_PATH
-    - name: Set NO_NASM env var (Windows)
-      if: matrix.env_no_nasm == 'set'
-      run: echo OPENSSL_RUST_NO_NASM=1 >> $GITHUB_ENV
     - name: Run tests (Windows)
       if: startsWith(matrix.os, 'windows')
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,7 +106,7 @@ jobs:
         WINNASMVERSION='2.15.05'
         curl -O https://www.nasm.us/pub/nasm/releasebuilds/${WINNASMVERSION}/win64/nasm-${WINNASMVERSION}-win64.zip
         unzip nasm-${WINNASMVERSION}-win64.zip
-        echo "$PWD/nasm-${WINNASMVERSION}" >> $GITHUB_PATH
+        echo "$GITHUB_WORKSPACE\\nasm-${WINNASMVERSION}" >> $GITHUB_PATH
         echo "OPENSSL_RUST_USE_NASM=yes" >> $GITHUB_ENV
     - name: Run tests (Windows)
       if: startsWith(matrix.os, 'windows')

--- a/README.md
+++ b/README.md
@@ -16,13 +16,20 @@ This project is licensed under either of
 at your option.
 
 ### Windows MSVC Assembly
-Building the `windows-msvc` targets on Windows, the build process will
-automatically detect whether [nasm](https://www.nasm.us/) is installed in PATH.
-The assembly language routines will be enabled if `nasm.exe` is found in PATH (in
-other words, the `no-asm` option will NOT be configured).  
-You can disable the this by set the `OPENSSL_RUST_NO_NASM` environment variable to
-a non-zero value. This environment variable does not take effects on non-windows
-platforms.
+Building OpenSSL for `windows-msvc` targets, users can choose whether to enable
+assembly language routines, which requires [nasm](https://www.nasm.us/).  
+The build process will automatically detect whether `nasm.exe` is installed in
+PATH. If found, the assembly language routines will be enabled (in other words,
+the `no-asm` option will NOT be configured).  
+You can manipulate this behavior by setting the `OPENSSL_RUST_USE_NASM` environment
+variable:
+* `yes`, `y`, `on`, `true`, `t` or `1`: Force enable the assembly language routines.
+(panic if `nasm.exe` is not availible.)
+* `no`, `n`, `off`, `false`, `f` or `-1`: Force disable the assembly language
+routines even if the `nasm.exe` can be found in PATH.
+* `auto`, `a`, `0` or not set: Let the build process automatically detect whether
+`nasm.exe` is installed. If found, enable. If not, disable.
+However, this environment variable does not take effects on non-windows platforms.
 
 ### Contribution
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ PATH. If found, the assembly language routines will be enabled (in other words,
 the `no-asm` option will NOT be configured).  
 You can manipulate this behavior by setting the `OPENSSL_RUST_USE_NASM` environment
 variable:
-* `yes` or `y`: Force enable the assembly language routines. (panic if `nasm.exe`
-is not availible.)
-* `no` or `n`: Force disable the assembly language routines even if the `nasm.exe`
-can be found in PATH.
-* `auto`, `a` or not set: Let the build process automatically detect whether
-`nasm.exe` is installed. If found, enable. If not, disable.
+* `1`: Force enable the assembly language routines. (panic if `nasm.exe` is not
+availible.)
+* `0`: Force disable the assembly language routines even if the `nasm.exe` can be
+found in PATH.
+* not set: Let the build process automatically detect whether `nasm.exe` is
+installed. If found, enable. If not, disable.
 However, this environment variable does not take effects on non-windows platforms.
 
 ### Contribution

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ This project is licensed under either of
 
 at your option.
 
+### Windows MSVC Assembly
+Building the `windows-msvc` targets on Windows, the build process will
+automatically detect whether [nasm](https://www.nasm.us/) is installed in PATH.
+The assembly language routines will be enabled if `nasm.exe` is found in PATH (in
+other words, the `no-asm` option will NOT be configured).  
+You can disable the this by set the `OPENSSL_RUST_NO_NASM` environment variable to
+a non-zero value. This environment variable does not take effects on non-windows
+platforms.
+
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ PATH. If found, the assembly language routines will be enabled (in other words,
 the `no-asm` option will NOT be configured).  
 You can manipulate this behavior by setting the `OPENSSL_RUST_USE_NASM` environment
 variable:
-* `yes`, `y`, `on`, `true`, `t` or `1`: Force enable the assembly language routines.
-(panic if `nasm.exe` is not availible.)
-* `no`, `n`, `off`, `false`, `f` or `-1`: Force disable the assembly language
-routines even if the `nasm.exe` can be found in PATH.
-* `auto`, `a`, `0` or not set: Let the build process automatically detect whether
+* `yes` or `y`: Force enable the assembly language routines. (panic if `nasm.exe`
+is not availible.)
+* `no` or `n`: Force disable the assembly language routines even if the `nasm.exe`
+can be found in PATH.
+* `auto`, `a` or not set: Let the build process automatically detect whether
 `nasm.exe` is installed. If found, enable. If not, disable.
 However, this environment variable does not take effects on non-windows platforms.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,9 +73,9 @@ impl Build {
                 .expect("The environment variable has invalid Unicode")
                 .to_lowercase();
             match &tmp[..] {
-                "y" | "yes" | "on" | "true" | "t" | "1" => Some(true),
-                "n" | "no" | "off" | "false" | "f" | "-1" => Some(false),
-                "a" | "auto" | "0" => None,
+                "y" | "yes" => Some(true),
+                "n" | "no" => Some(false),
+                "a" | "auto" => None,
                 _ => panic!(
                     "The environment variable {} is set to an unrecognizable value: {}",
                     var_name, tmp


### PR DESCRIPTION
issue #59

For Windows users, if the `OPENSSL_RUST_USE_NASM` environment variable is set, the assembly language routines will be enabled.

Tested on Windows 10 64bit (20H2), VS Community 2019 (16.9.1), rustc 1.50.0 (stable-x86_64-pc-windows-msvc), NASM version 2.15.05.