### PR TITLE
Add FreeBSD powerpc support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,6 +248,7 @@ impl Build {
             "mips64el-unknown-linux-gnuabi64" => "linux64-mips64",
             "mipsel-unknown-linux-gnu" => "linux-mips32",
             "mipsel-unknown-linux-musl" => "linux-mips32",
+            "powerpc-unknown-freebsd" => "BSD-generic32",
             "powerpc-unknown-linux-gnu" => "linux-ppc",
             "powerpc64-unknown-freebsd" => "BSD-generic64",
             "powerpc64-unknown-linux-gnu" => "linux-ppc64",


### PR DESCRIPTION
This is needed to support cargo cross-build for 32-bit powerpc on FreeBSD.