### PR TITLE
Handling unwrap errors in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,7 +543,7 @@ fn sanitize_sh(path: &Path) -> String {
             None => {
                 panic!("Failed to find path {:?}", &path);
             }
-        }
+        };
     }
 
     let path = match path.to_str() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -538,7 +538,12 @@ fn apply_patches_musl(target: &str, inner: &Path) {
 
 fn sanitize_sh(path: &Path) -> String {
     if !cfg!(windows) {
-        return path.to_str().unwrap().to_string();
+        return match path.to_str() {
+            Some(value) => value.to_string(),
+            None => {
+                panic!("Failed to find path {:?}", &path);
+            }
+        }
     }
 
     let path = match path.to_str() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,8 +544,7 @@ fn sanitize_sh(path: &Path) -> String {
     let path = match path.to_str() {
         Some(value) => value.replace("\\", "/"),
         None => {
-            eprintln!("Failed to find path {:?}", &path);
-            panic!();
+            panic!("Failed to find path {:?}", &path);
         }
     };
     return change_drive(&path).unwrap_or(path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,7 +541,7 @@ fn sanitize_sh(path: &Path) -> String {
         return match path.to_str() {
             Some(value) => value.to_string(),
             None => {
-                panic!("Failed to find path {:?}", &path);
+                panic!("Failed to convert path to string: {:?}", &path);
             }
         };
     }
@@ -549,7 +549,7 @@ fn sanitize_sh(path: &Path) -> String {
     let path = match path.to_str() {
         Some(value) => value.replace("\\", "/"),
         None => {
-            panic!("Failed to find path {:?}", &path);
+            panic!("Failed to convert path to string: {:?}", &path);
         }
     };
     return change_drive(&path).unwrap_or(path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,7 +477,7 @@ impl Build {
         let status = match command.status() {
             Ok(value) => value,
             Err(error) => {
-                panic!("Error running command {:?} => {:?}", command, error);
+                panic!("Error running command => {:?}", error);
             }
         };
         if !status.success() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,7 +540,14 @@ fn sanitize_sh(path: &Path) -> String {
     if !cfg!(windows) {
         return path.to_str().unwrap().to_string();
     }
-    let path = path.to_str().unwrap().replace("\\", "/");
+
+    let path = match path.to_str() {
+        Some(value) => value.replace("\\", "/"),
+        None => {
+            eprintln!("Failed to find path {:?}", &path);
+            panic!();
+        }
+    };
     return change_drive(&path).unwrap_or(path);
 
     fn change_drive(s: &str) -> Option<String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,7 +474,12 @@ impl Build {
 
     fn run_command(&self, mut command: Command, desc: &str) {
         println!("running {:?}", command);
-        let status = command.status().unwrap();
+        let status = match command.status() {
+            Ok(value) => value,
+            Err(error) => {
+                panic!("Error running command {:?} => {:?}", command, error);
+            }
+        };
         if !status.success() {
             panic!(
                 "


### PR DESCRIPTION
This blind unwrap seems to be a very common error in builds, when it panics it gives the end user no clear way of identifying what's wrong, this PR adds some handling to show the file path that can't be found.