### PR TITLE
Upgrade to OpenSSL v3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl-src"
-version = "111.16.0+1.1.1l"
+version = "300.0.0+3.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,11 @@ impl Build {
             // Nothing related to zlib please
             .arg("no-comp")
             .arg("no-zlib")
-            .arg("no-zlib-dynamic");
+            .arg("no-zlib-dynamic")
+            // Avoid multilib-postfix for build targets that specify it
+            .arg("--libdir=lib")
+            // No support for multiple providers yet
+            .arg("no-legacy");
 
         if cfg!(not(feature = "weak-crypto")) {
             configure


### PR DESCRIPTION
On amd64, trying to compile a project (https://github.com/deltachat/deltachat-core-rust) that uses openssl-sys and vendors openssl via openssl-src, gets me this:

```
thread 'main' panicked at 'OpenSSL library directory does not exist: deltachat-core-rust/target/debug/build/openssl-sys-72260f2c868a930d/out/openssl-build/install/lib', openssl-sys/build/main.rs:66:9
  stack backtrace:
     0: rust_begin_unwind
               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/panicking.rs:515:5
     1: std::panicking::begin_panic_fmt
               at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/panicking.rs:457:5
     2: build_script_main::main
     3: core::ops::function::FnOnce::call_once
  note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
This is solved by passing `--libdir=lib` to the configure script.


There's also a warning to do with `bin_dir`:

```
Compiling openssl-src v300.0.0+3.0.0 (/home/lupine/dev/github.com/deltachat/openssl-src-rs)
warning: field is never read: `bin_dir`
  --> /home/lupine/dev/github.com/deltachat/openssl-src-rs/src/lib.rs:25:5
   |
25 |     bin_dir: PathBuf,
   |     ^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```

But, it does compile and successfully vendor in openssl 3:

```
$ target/debug/examples/repl foo
OpenSSL 3.0.0 7 sep 2021
Delta Chat Core is awaiting your commands.
```

OpenSSL 3 has a better license for combination with GPL software that doesn't include the OpenSSL exemption, which is why I'm playing with this ^^