### PR TITLE
Fix building against OpenSSL 3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ repository = "https://github.com/alexcrichton/openssl-src-rs"
 description = """
 Source of OpenSSL and logic to build it.
 """
+
+# Keep this list in sync with ci/run.sh
 exclude = [
   'openssl/boringssl/*',
   'openssl/fuzz/*',

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -16,7 +16,7 @@ docker build \
 docker run \
   --rm \
   --volume `rustc --print sysroot`:/rust:ro \
-  --volume `pwd`:/usr/code:ro \
+  --volume `pwd`:/usr/code \
   --volume `pwd`/target:/usr/code/target \
   --volume $HOME/.cargo:/cargo \
   --env CARGO_HOME=/cargo \

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -8,6 +8,14 @@ if [ "$1" = "aarch64-apple-darwin" ] ; then
 	export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER=echo
 fi
 
+# Remove directories that are excluded by Cargo.toml
+rm -rf openssl/boringssl
+rm -rf openssl/fuzz
+rm -rf openssl/krb5
+rm -rf openssl/pyca-cryptography
+rm -rf openssl/test
+rm -rf openssl/wycheproof
+
 cargo test --manifest-path testcrate/Cargo.toml --target $1 -vv
 cargo test --manifest-path testcrate/Cargo.toml --target $1 -vv --release
 if [ "$1" = "x86_64-unknown-linux-gnu" ] ; then

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,13 @@ impl Build {
         fs::create_dir_all(&inner_dir).unwrap();
         cp_r(&source_dir(), &inner_dir);
 
+        // OpenSSL 3.0.0 requires an empty build.info file in these directories
+        // to configure itself
+        fs::create_dir_all(inner_dir.join("fuzz")).unwrap();
+        fs::create_dir_all(inner_dir.join("test")).unwrap();
+        fs::File::create(inner_dir.join("fuzz/build.info")).unwrap();
+        fs::File::create(inner_dir.join("test/build.info")).unwrap();
+
         let perl_program =
             env::var("OPENSSL_SRC_PERL").unwrap_or(env::var("PERL").unwrap_or("perl".to_string()));
         let mut configure = Command::new(perl_program);


### PR DESCRIPTION
Unlike OpenSSL 1, OpenSSL 3 requires build.info files in its `test/` and `fuzz/` directories to be present. Without them, the configure script fails. They're excluded from the crate for space reasons; account for this in the build script by creating empty files to be included, since these features are disabled anyway.

More information here: https://github.com/alexcrichton/openssl-src-rs/pull/102

Signed-off-by: Nick Thomas <me@ur.gs>