### PR TITLE
Try excluding the fuzz corpora from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
   'openssl/pyca-cryptography/*',
   'openssl/test/*',
   'openssl/wycheproof/*',
+  'openssl/fuzz/corpora/*',
 ]
 
 [features]


### PR DESCRIPTION
Otherwise we're still sitting at 12M which is too big for crates.io