### PR TITLE
Enable the engine feature on windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ impl Build {
             // to correctly pick up crypt32.lib functions such as
             // `__imp_CertOpenStore` when building the capieng engine.
             // Let's disable just capieng.
-            config.arg("no-capieng");
+            configure.arg("no-capieng");
         }
 
         if target.contains("musl") {


### PR DESCRIPTION
I'm doing things on Windows and that require the `engine` feature to be enabled so that `ENGINE_by_id` is available.
This commit succeeds for me locally in a win64 msvc environment.
