### PR TITLE
Fix OpenSSL 3.0.0 on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ description = """
 Source of OpenSSL and logic to build it.
 """
 exclude = [
-  'openssl/boringssl/*',
-  'openssl/demos/*',
-  'openssl/doc/*',
-  'openssl/krb5/*',
-  'openssl/pyca-cryptography/*',
-  'openssl/test/*',
-  'openssl/wycheproof/*',
   'openssl/fuzz/corpora/*',
+  'openssl/pyca-cryptography/*',
+  'openssl/wycheproof/*',
+  'openssl/boringssl/*',
+  'openssl/krb5/*',
+  'openssl/test/recipes/*',
+  'openssl/gost-engine/*',
+  'openssl/demos/*',
 ]
 
 [features]
@@ -36,6 +36,7 @@ seed = []
 
 [workspace]
 members = ['testcrate']
+exclude = ['target']
 
 [dependencies]
 cc = "1.0"

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,24 +1,42 @@
+#!/bin/bash
+
 target=$1
 testcrate_dir="$(pwd)/testcrate"
 set -ex
 
 if [ "$1" = "aarch64-apple-darwin" ] ; then
-	sudo xcode-select -s /Applications/Xcode_12.2.app/Contents/Developer/
-	export SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path)
-	export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version)
-	export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER=echo
+  sudo xcode-select -s /Applications/Xcode_12.2.app/Contents/Developer/
+  export SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path)
+  export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version)
+  export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER=echo
 fi
 
 cargo test --manifest-path "$testcrate_dir/Cargo.toml" --target $1 -vv
 cargo test --manifest-path "$testcrate_dir/Cargo.toml" --target $1 -vv --release
 
 if [ "$1" = "x86_64-unknown-linux-gnu" ] ; then
-	cargo test --manifest-path "$testcrate_dir/Cargo.toml" --target $1 -vv --all-features
+  cargo test --manifest-path "$testcrate_dir/Cargo.toml" --target $1 -vv --all-features
 
-	# Ensure we don't rely on any files excluded by Cargo.toml
-	rm -rf target/ci
-	cargo package --allow-dirty --target-dir target/ci
-	rm -f target/ci/package/*.crate
-	cd target/ci/package/openssl-src-*
-	cargo test --manifest-path "$testcrate_dir/Cargo.toml" --target $1 -vv
+  # Run a few tests here:
+  #
+  # * Make sure the packaged crate file isn't bigger than 10MB which is
+  #   crate.io's limit.
+  # * Make sure that the package crate itself works.
+  #
+  # A lot of OpenSSL's source code is excluded on crates.io because it makes the
+  # crate file much too large, so the test here should inform us if we're
+  # missing anything actually required to build OpenSSL.
+  rm -rf target/ci
+  cargo package --allow-dirty --target-dir target/ci
+  crate=`ls target/ci/package/*.crate`
+  filesize=$(stat -c%s "$crate")
+  echo "tarball is $filesize bytes"
+  if (( filesize > 10000000 )); then
+    echo "file size too big"
+    exit 1
+  fi
+  rm "$crate"
+  cd target/ci/package/openssl-src-*
+  cp -r "$testcrate_dir" .
+  cargo test --manifest-path "testcrate/Cargo.toml" --target $1 -vv
 fi


### PR DESCRIPTION
Actually fix `run.sh` and find a set of `exclude`-ed files which allows
the crate to still build.

Closes #105