### PR TITLE
Allow the legacy provider to be enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ exclude = [
 
 [features]
 default = []
+# Enables compilation of the legacy provider, which must be loaded at runtime to use various
+# uncommon or insecure algorithms.
+legacy = []
 # Enables compilation of some older algorithms: md2 (hash), rc5 (block cypher) and enabled use of
 # some weaker algorithms in SSL connections. These are generally not recommended for use.
 weak-crypto = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,9 +153,11 @@ impl Build {
             .arg("no-zlib")
             .arg("no-zlib-dynamic")
             // Avoid multilib-postfix for build targets that specify it
-            .arg("--libdir=lib")
-            // No support for multiple providers yet
-            .arg("no-legacy");
+            .arg("--libdir=lib");
+
+        if cfg!(not(feature = "legacy")) {
+            configure.arg("no-legacy");
+        }
 
         if cfg!(not(feature = "weak-crypto")) {
             configure


### PR DESCRIPTION
The provider ends up bundled into libcrypto.a, and loading the provider at runtime seems to work. The legacy provider is required to interface with things like PKCS#12 archives constructed with the default settings of earlier OpenSSL releases.