### PR TITLE
Support riscv64gc-unknown-freebsd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,7 @@ impl Build {
             "powerpc64le-unknown-freebsd" => "BSD-generic64",
             "powerpc64le-unknown-linux-gnu" => "linux-ppc64le",
             "powerpc64le-unknown-linux-musl" => "linux-ppc64le",
+            "riscv64gc-unknown-freebsd" => "BSD-generic64",
             "riscv64gc-unknown-linux-gnu" => "linux-generic64",
             "s390x-unknown-linux-gnu" => "linux64-s390x",
             "s390x-unknown-linux-musl" => "linux64-s390x",


### PR DESCRIPTION
Also see https://github.com/rust-lang/rust/pull/91284