### PR TITLE
Support compiling to wasm32-wasi target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,8 +218,9 @@ impl Build {
         }
 
         if target.contains("wasm") {
+            // -no-threads we dont have thread support in WASI
             configure.arg("no-threads");
-            configure.arg("no-asm");
+            // -no-sock we dont have sockets in WASI
             configure.arg("no-sock");
             configure.arg("no-afalgeng");
             configure.arg("-DOPENSSL_SYS_NETWARE");
@@ -227,6 +228,7 @@ impl Build {
             configure.arg("-DSIG_IGN=0");
             configure.arg("-DHAVE_FORK=0");
             configure.arg("-DOPENSSL_NO_AFALGENG=1");
+            // --with-rand-seed=getrandom (needed to force using getentropy because WASI has no /dev/random or getrandom)
             configure.arg("--with-rand-seed=getrandom");
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ impl Build {
 
     fn cmd_make(&self) -> Command {
         let host = &self.host.as_ref().expect("HOST dir not set")[..];
+        let target = &self.target.as_ref().expect("TARGET dir not set")[..];
         if host.contains("dragonfly")
             || host.contains("freebsd")
             || host.contains("openbsd")
@@ -61,7 +62,13 @@ impl Build {
         {
             Command::new("gmake")
         } else {
-            Command::new("make")
+            if target.contains("wasm") {
+                let mut cmd = Command::new("wasimake");
+
+                std::mem::replace(cmd.arg("make"),Command::new("wasimake"))
+            } else {
+                Command::new("make")
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,19 @@ impl Build {
             configure.arg("no-stdio");
         }
 
+        if target.contains("wasm") {
+            configure.arg("no-threads");
+            configure.arg("no-asm");
+            configure.arg("no-sock");
+            configure.arg("no-afalgeng");
+            configure.arg("-DOPENSSL_SYS_NETWARE");
+            configure.arg("-DSIG_DFL=0");
+            configure.arg("-DSIG_IGN=0");
+            configure.arg("-DHAVE_FORK=0");
+            configure.arg("-DOPENSSL_NO_AFALGENG=1");
+            configure.arg("--with-rand-seed=getrandom");
+        }
+
         if target.contains("msvc") {
             // On MSVC we need nasm.exe to compile the assembly files.
             // ASM compiling will be enabled if nasm.exe is installed, unless

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ impl Build {
             if target.contains("wasm") {
                 let mut cmd = Command::new("wasimake");
 
-                std::mem::replace(cmd.arg("make"),Command::new("wasimake"))
+                std::mem::replace(cmd.arg("make"), Command::new("wasimake"))
             } else {
                 Command::new("make")
             }
@@ -142,8 +142,8 @@ impl Build {
         if target.contains("wasm") {
             program = String::from("wasiconfigure");
         } else {
-            program =
-                env::var("OPENSSL_SRC_PERL").unwrap_or(env::var("PERL").unwrap_or("perl".to_string()));
+            program = env::var("OPENSSL_SRC_PERL")
+                .unwrap_or(env::var("PERL").unwrap_or("perl".to_string()));
         }
 
         let mut configure = Command::new(program);


### PR DESCRIPTION
Adds support for compiling to wasm32-wasi target

# Changes

- added the usage of `wasiconfigure` and `wasimake` when targeting wasm
- added wasm-wasi specific config options

# Issues

- https://github.com/sfackler/rust-openssl/issues/1016