### PR TITLE
Fix aarch64-apple-darwin CI

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -5,9 +5,6 @@ testcrate_dir="$(pwd)/testcrate"
 set -ex
 
 if [ "$1" = "aarch64-apple-darwin" ] ; then
-  sudo xcode-select -s /Applications/Xcode_12.2.app/Contents/Developer/
-  export SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path)
-  export MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version)
   export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER=echo
 fi
 


### PR DESCRIPTION
These lines should no longer be necessary.  The default XCode is now 13.1 (and I believe the default SDK is macos 12.0).  I believe these were added since at the time the default xcode did not support aarch64-apple-darwin.