### PR TITLE
Support bitbake's x86_64-linux

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,6 +285,7 @@ impl Build {
             "thumbv7a-uwp-windows-msvc" => "VC-WIN32-ARM-UWP",
             "x86_64-apple-darwin" => "darwin64-x86_64-cc",
             "x86_64-linux-android" => "linux-x86_64",
+            "x86_64-linux" => "linux-x86_64",
             "x86_64-pc-windows-gnu" => "mingw64",
             "x86_64-pc-windows-msvc" => "VC-WIN64A",
             "x86_64-unknown-freebsd" => "BSD-x86_64",


### PR DESCRIPTION
When meta-rust is used for compiling openssl-sys it fails with the
following error:
| error: failed to run custom build command for `openssl-sys v0.9.61`
|
| Caused by:
|   process didn't exit successfully: `/home/builder/src/base/build/tmp/work/x86_64-linux/cargo-deny-native/0.9.1-r0/build/target/release/build/openssl-sys-ec38bc05b130195f/build-script-main` (exit code: 101)
|   --- stdout
|   cargo:rustc-cfg=const_fn
|   cargo:rerun-if-env-changed=X86_64_LINUX_OPENSSL_NO_VENDOR
|   X86_64_LINUX_OPENSSL_NO_VENDOR unset
|   cargo:rerun-if-env-changed=OPENSSL_NO_VENDOR
|   OPENSSL_NO_VENDOR unset
|
|   --- stderr
|   thread 'main' panicked at 'don't know how to configure OpenSSL for x86_64-linux', /home/builder/src/base/build/tmp/work/x86_64-linux/cargo-deny-native/0.9.1-r0/cargo_home/bitbake/openssl-src-111.15.0+1.1.1k/src/lib.rs:275:18
|   stack backtrace:
|      0: rust_begin_unwind
|      1: std::panicking::begin_panic_fmt
|      2: openssl_src::Build::build
|      3: build_script_main::find_vendored::get_openssl
|      4: build_script_main::find_openssl
|      5: build_script_main::main
|      6: core::ops::function::FnOnce::call_once
|   note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
| warning: build failed, waiting for other jobs to finish...

In meta-rust "--target" is set to HOST_SYS which is set to
"x86_64-linux" on x86_64 systems.