### PR TITLE
Emit a better error message when a command failed to execute.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -534,21 +534,25 @@ impl Build {
 
     fn run_command(&self, mut command: Command, desc: &str) {
         println!("running {:?}", command);
-        let status = command.status().unwrap();
-        if !status.success() {
-            panic!(
-                "
+        let status = command.status();
+
+        let (status_or_failed, error) = match status {
+            Ok(status) if status.success() => return,
+            Ok(status) => ("Exit status", format!("{}", status)),
+            Err(failed) => ("Failed to execute", format!("{}", failed)),
+        };
+        panic!(
+            "
 
 
 Error {}:
     Command: {:?}
-    Exit status: {}
+    {}: {}
 
 
     ",
-                desc, command, status
-            );
-        }
+            desc, command, status_or_failed, error
+        );
     }
 }
 


### PR DESCRIPTION
I hit this when 'perl' wasn't installed on my windows machine, when trying to `cargo install gitui`.
The long and verbose output made it hard to notice the actual error (`program not found`) hiding in the panic message.
It's still verbose, but the better formatting should improve readability.

Before:
```
error: failed to run custom build command for `openssl-sys v0.9.72`

Caused by:
  process didn't exit successfully: `D:\Dokumente\Rust\gitui\target\debug\build\openssl-sys-3446ba0d2783aba7\build-script-main` (exit code: 101)
  --- stdout
  [ ... ]

  --- stderr
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { kind: NotFound, message: "program not found" }', C:\Users\Julian\.cargo\registry\src\github.com-1ecc6299db9ec823\openssl-src-111.17.0+1.1.1m\src\lib.rs:477:39
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed
```

After:
```
error: failed to run custom build command for `openssl-sys v0.9.72`

Caused by:
  process didn't exit successfully: `D:\Dokumente\Rust\gitui\target\release\build\openssl-sys-76722f0f88dd29d1\build-script-main` (exit code: 101)
  --- stdout
  [...]

  --- stderr
  thread 'main' panicked at '


  Error configuring OpenSSL build:
      Command: "perl" "./Configure" "--prefix=D:\\Dokumente\\Rust\\gitui\\target\\release\\build\\openssl-sys-e94b178bbce3b1da\\out\\openssl-build\\install" "no-dso
" "no-shared" "no-ssl3" "no-unit-test" "no-comp" "no-zlib" "no-zlib-dynamic" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "no-engine" "
no-asm" "VC-WIN64A"
      Failed to execute: program not found


      ', D:\Dokumente\Rust\openssl-src-rs\src\lib.rs:484:9
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
error: build failed

```