### PR TITLE
Add aarch64-apple-ios-sim target to 111 release

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,7 @@ impl Build {
             "wasm32-wasi" => "gcc",
             "aarch64-apple-ios" => "ios64-cross",
             "x86_64-apple-ios" => "iossimulator-xcrun",
+            "aarch64-apple-ios-sim" => "iossimulator-xcrun",
             _ => panic!("don't know how to configure OpenSSL for {}", target),
         };
 


### PR DESCRIPTION
I'm not sure this is the preferred flow for adding this change to the 111 release but figured I could create an issue to ask or just do it.