### PR TITLE
Enable engine support for musl

### DIFF
--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -6,4 +6,10 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   perl \
   gcc \
   libc6-dev \
-  musl-tools
+  musl-tools \
+  linux-headers-4.15.0-20-generic
+
+# link up the musl headers
+RUN ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/x86_64-linux-musl/asm \
+  && ln -s /usr/include/asm-generic /usr/include/x86_64-linux-musl/asm-generic \
+  && ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux

--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -6,10 +6,4 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   perl \
   gcc \
   libc6-dev \
-  musl-tools \
-  linux-headers-4.15.0-20-generic
-
-# link up the musl headers
-RUN ln -s /usr/include/x86_64-linux-gnu/asm /usr/include/x86_64-linux-musl/asm \
-  && ln -s /usr/include/asm-generic /usr/include/x86_64-linux-musl/asm-generic \
-  && ln -s /usr/include/linux /usr/include/x86_64-linux-musl/linux
+  musl-tools

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,11 +194,7 @@ impl Build {
             configure.arg("no-seed");
         }
 
-        if target.contains("musl") {
-            // This actually fails to compile on musl (it needs linux/version.h
-            // right now) but we don't actually need this most of the time.
-            configure.arg("no-engine");
-        } else if target.contains("windows") {
+        if target.contains("windows") {
             // We can build the engine feature, but the build doesn't seem
             // to correctly pick up crypt32.lib functions such as
             // `__imp_CertOpenStore` when building the capieng engine.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@ pub struct Build {
     out_dir: Option<PathBuf>,
     target: Option<String>,
     host: Option<String>,
-    force_engine: bool,
 }
 
 pub struct Artifacts {
@@ -34,7 +33,6 @@ impl Build {
             out_dir: env::var_os("OUT_DIR").map(|s| PathBuf::from(s).join("openssl-build")),
             target: env::var("TARGET").ok(),
             host: env::var("HOST").ok(),
-            force_engine: false,
         }
     }
 
@@ -50,11 +48,6 @@ impl Build {
 
     pub fn host(&mut self, host: &str) -> &mut Build {
         self.host = Some(host.to_string());
-        self
-    }
-
-    pub fn force_engine(&mut self) -> &mut Build {
-        self.force_engine = true;
         self
     }
 
@@ -204,8 +197,8 @@ impl Build {
         if target.contains("musl") {
             // The engine module fails compile on musl (it needs linux/version.h
             // right now) but we don't actually need this most of the time, so
-            // disable it unless force option is specified.
-            if !self.force_engine {
+            // disable it unless force-engine feature is specified.
+            if !cfg!(feature = "force-engine") {
                 configure.arg("no-engine");
             }
         } else if target.contains("windows") {


### PR DESCRIPTION
In one of our (vector.dev) project's dependencies (rdkafka), a hard dependency on openssl Engine support was added.
This resulted in cross compilation errors for our project (since openssl-src was not enabling the engine support), the findings were documented here:

https://github.com/vectordotdev/vector/pull/10302

In particular, I found that if I made the below change to openssl-src , I was able to successfully compile to the target `x86_64-unknown-linux-musl` using `cross`.

Would this be an acceptable change to make in openssl-src with this knowledge ?

Thanks!

