### PR TITLE
add force-engine feature for enabling engine module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,10 +185,13 @@ impl Build {
         }
 
         if target.contains("musl") || target.contains("windows") {
-            // This actually fails to compile on musl (it needs linux/version.h
+            // Engine module fails to compile on musl (it needs linux/version.h
             // right now) but we don't actually need this most of the time.
             // API of engine.c ld fail in Windows.
-            configure.arg("no-engine");
+            // Disable engine module unless force-engine feature specified
+            if !cfg!(feature = "force-engine") {
+                configure.arg("no-engine");
+            }
         }
 
         if target.contains("musl") {


### PR DESCRIPTION
In one of our (vector.dev) project's dependencies (rdkafka), a hard dependency on openssl Engine support was added.
This resulted in cross compilation errors for our project (since openssl-src was not enabling the engine support), the findings were documented here:

https://github.com/vectordotdev/vector/pull/10302

Allowing this engine feature support to be configurable would help unblock us.

Thanks!