### PR TITLE
Bump to 3.0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl-src"
-version = "300.0.9+3.0.5"
+version = "300.0.10+3.0.6"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
https://github.com/openssl/openssl/releases/tag/openssl-3.0.6