### PR TITLE
Correctly infer ranlib/ar from cross-gcc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,15 +346,16 @@ impl Build {
             configure.env_remove("CROSS_COMPILE");
 
             // Infer ar/ranlib tools from cross compilers if the it looks like
-            // we're doing something like `foo-gcc` route that to `foo-ranlib`
+            // we're doing something like `foo-gcc` route that to `foo-gcc-ranlib`
             // as well.
             if path.ends_with("-gcc") && !target.contains("unknown-linux-musl") {
-                let path = &path[..path.len() - 4];
+                let suffix = &path[path.len() - 4..];
+                let path = &path[..path.len() - suffix.len()];
                 if env::var_os("RANLIB").is_none() {
-                    configure.env("RANLIB", format!("{}-ranlib", path));
+                    configure.env("RANLIB", format!("{}{}-ranlib", path, suffix));
                 }
                 if env::var_os("AR").is_none() {
-                    configure.env("AR", format!("{}-ar", path));
+                    configure.env("AR", format!("{}{}-ar", path, suffix));
                 }
             }
 


### PR DESCRIPTION
The GCC convention is that if the toolchain is named `$target-gnu-gcc`, then ranlib and ar will be available as `$target-gnu-gcc-ranlib` and `$target-gnu-gcc-ar` respectively. The code as written would infer them to be `$target-gnu-{ranlib,ar}`, which won't work.

I'm not sure why the code that existed was written the way it was -- I don't know of any GCC toolchains where the `-gcc` is stripped out in the name of ranlib/ar. The file listing on Debian's [GCC 6.x] and [GCC 10.x] all show the binaries using the `$target-gnu-gcc-$bin` format, as does Arch Linux's [GCC 12.x].

This error appears to also be present in the `cc` crate. There, the `-gcc` prefix is always stripped ([1][cc1], [2][cc2]), and then `-ar` is [appended]. But its saving grace is that it also checks if the resulting binary name is executable, and if it isn't falls back to the default AR instead, which means the bad heuristic is likely often masked by the presence of another working default AR. This crate does not (but perhaps it should?).

[GCC 6.x]: https://packages.debian.org/stretch/gcc
[GCC 10.x]: https://packages.debian.org/stable/devel/gcc
[GCC 12.x]: https://archlinux.org/packages/core/x86_64/gcc/
[cc1]: https://github.com/rust-lang/cc-rs/blob/8daff16ce11e2753961c9b0ce3398fdeada6d941/src/lib.rs#L2623-L2626
[cc2]: https://github.com/rust-lang/cc-rs/blob/8daff16ce11e2753961c9b0ce3398fdeada6d941/src/lib.rs#L2769
[appended]: https://github.com/rust-lang/cc-rs/blob/8daff16ce11e2753961c9b0ce3398fdeada6d941/src/lib.rs#L2602-L2604