### PR TITLE
Correctly infer ranlib/ar for cross-gcc toolchains

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,7 +357,7 @@ impl Build {
                         break;
                     }
 
-                    for &infix in &[suffix, ""] {
+                    for &infix in &["", suffix] {
                         let candidate = format!("{}{}-{}", path, infix, tool.to_lowercase());
                         // Only choose a tool if it's actually executable
                         if Command::new(&candidate).output().is_ok() {


### PR DESCRIPTION
A second try at #163.

The GCC convention is that if the toolchain is named `$target-gnu-gcc`, then ranlib and ar will be available as `$target-gnu-gcc-ranlib` and `$target-gnu-gcc-ar` respectively. The code as written would infer them to be `$target-gnu-{ranlib,ar}`, which will only work if the tools from `binutils` (which follow that convention) are on `$PATH`.

I've also updated the logic in line with the `cc` crate to check that the inferred `AR`/`RANLIB` is actually executable before setting it as an override.

See also rust-lang/cc-rs#736.