### PR TITLE
impl OPENSSL_SRC_PREFIX_SANTIZE env var

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,8 @@ impl Build {
         let build_dir = out_dir.join("build");
         let install_dir = out_dir.join("install");
 
+        println!("\nopenssl-src::Build\ntarget = {}\nhost = {}\nout_dir = {}\nbuild_dir = {}\ninstall_dir = {}\nis cfg Windows = {}\n", target, host, out_dir.display(), build_dir.display(), install_dir.display(), !cfg!(windows));
+
         if build_dir.exists() {
             fs::remove_dir_all(&build_dir).unwrap();
         }
@@ -136,7 +138,9 @@ impl Build {
         configure.arg("./Configure");
 
         // Change the install directory to happen inside of the build directory.
-        if host.contains("pc-windows-gnu") {
+        // Sanitize also if env var is set
+        let sanitize = env::var("OPENSSL_SRC_PREFIX_SANITIZE_SH").unwrap_or("false".to_string());
+        if host.contains("pc-windows-gnu") || sanitize.contains("true") {
             configure.arg(&format!("--prefix={}", sanitize_sh(&install_dir)));
         } else {
             configure.arg(&format!("--prefix={}", install_dir.display()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ impl Build {
         let build_dir = out_dir.join("build");
         let install_dir = out_dir.join("install");
 
-        println!("\nopenssl-src::Build\ntarget = {}\nhost = {}\nout_dir = {}\nbuild_dir = {}\ninstall_dir = {}\nis cfg Windows = {}\n", target, host, out_dir.display(), build_dir.display(), install_dir.display(), !cfg!(windows));
+        println!("\nopenssl-src::Build\ntarget = {}\nhost = {}\nout_dir = {}\nbuild_dir = {}\ninstall_dir = {}\nis cfg Windows = {}\n", target, host, out_dir.display(), build_dir.display(), install_dir.display(), cfg!(windows));
 
         if build_dir.exists() {
             fs::remove_dir_all(&build_dir).unwrap();


### PR DESCRIPTION
- Sanitize path forcefully based on env var
  - 2 use cases as issues #118 
- Dump some helpful build info when build fails