### PR TITLE
Use cc for ar/ranlib detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,4 +42,4 @@ members = ['testcrate']
 exclude = ['target']
 
 [dependencies]
-cc = "1.0"
+cc = "1.0.79"


### PR DESCRIPTION
Note that `Command::get_program` and `Command::get_args` both stabilized in Rust 1.57.0, and so implicitly bump this crate's MSRV.

Depends on rust-lang/cc-rs#763.

Replaces #164.