### PR TITLE
Added build target for aarch64-apple-ios-sim

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,6 +299,7 @@ impl Build {
             "wasm32-wasi" => "gcc",
             "aarch64-apple-ios" => "ios64-cross",
             "x86_64-apple-ios" => "iossimulator-xcrun",
+            "aarch64-apple-ios-sim" => "iossimulator-xcrun",
             _ => panic!("don't know how to configure OpenSSL for {}", target),
         };
 


### PR DESCRIPTION
This PR was opened before and closed because it was not a security fix (in #135). I do need this target so I created this fork which I am using now with `patch.crates-io`. This however does not really seem good to us, as we have to keep it up-to-date with this branch for security fixes. 

Signed-off-by: blu3beri <blu3beri@proton.me>