### PR TITLE
Add match for powerpc-unknown-linux-gnuspe

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,7 @@ impl Build {
             "mipsel-unknown-linux-musl" => "linux-mips32",
             "powerpc-unknown-freebsd" => "BSD-generic32",
             "powerpc-unknown-linux-gnu" => "linux-ppc",
+            "powerpc-unknown-linux-gnuspe" => "linux-ppc",
             "powerpc64-unknown-freebsd" => "BSD-generic64",
             "powerpc64-unknown-linux-gnu" => "linux-ppc64",
             "powerpc64-unknown-linux-musl" => "linux-ppc64",


### PR DESCRIPTION
Some powerpc builds (notably Freescale QoriQ used in a few Synology NAS products) identifies as `gnuspe`. When it comes to compiling things like openssl, it seems the compiler itself deals with this additional detail and so these builds can just use `linux-ppc` as far as I can tell.

I did a simple test locally on my Synology NAS, and there doesn't seem to be any immediate problems adding this.

PS.
What is the policy for adding this kind of changes to both this branch and the main branch?