### PR TITLE
Omit new submodules from uploaded crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ exclude = [
   'openssl/test/recipes/*',
   'openssl/gost-engine/*',
   'openssl/demos/*',
+  'openssl/tlslite-ng/*',
+  'openssl/tlsfuzzer/*',
+  'openssl/python-ecdsa/*',
+  'openssl/oqs-provider/*',
 ]
 
 [features]


### PR DESCRIPTION
Looks like the 3.1 release tipped the scales to this otherwise being larger than 10MB