### PR TITLE
Bump to 3.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl-src"
-version = "300.1.1+3.1.0"
+version = "300.1.2+3.1.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
https://github.com/openssl/openssl/releases/tag/openssl-3.1.1