### PR TITLE
Add force-engine feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ idea = []
 # Enables compilation of SEED, a symmetric key block cypher mostly used in South Korea, but
 # otherwise not widely supported.
 seed = []
+# Forces configuring Engine module support.
+force-engine = []
 
 [workspace]
 members = ['testcrate']

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,9 +196,12 @@ impl Build {
         }
 
         if target.contains("musl") {
-            // This actually fails to compile on musl (it needs linux/version.h
+            // Engine module fails to compile on musl (it needs linux/version.h
             // right now) but we don't actually need this most of the time.
-            configure.arg("no-engine");
+            // Disable engine module unless force-engine feature specified
+            if !cfg!(feature = "force-engine") {
+                configure.arg("no-engine");
+            }
         } else if target.contains("windows") {
             // We can build the engine feature, but the build doesn't seem
             // to correctly pick up crypt32.lib functions such as


### PR DESCRIPTION
Adding the `force-engine` feature flag to the 300 release.

See https://github.com/alexcrichton/openssl-src-rs/pull/151 for context.