### PR TITLE
fix: Sets AR for Android only if using GCC

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,22 +353,27 @@ impl Build {
             // prefix, we unset `CROSS_COMPILE` for `./Configure`.
             configure.env_remove("CROSS_COMPILE");
 
-            let ar = cc.get_archiver();
-            configure.env("AR", ar.get_program());
-            if ar.get_args().count() != 0 {
-                // On some platforms (like emscripten on windows), the ar to use may not be a
-                // single binary, but instead a multi-argument command like `cmd /c emar.bar`.
-                // We can't convey that through `AR` alone, and so also need to set ARFLAGS.
-                configure.env(
-                    "ARFLAGS",
-                    ar.get_args().collect::<Vec<_>>().join(OsStr::new(" ")),
-                );
+            // We don't have GCC in newer NDK versions.
+            if !target.contains("android") || (target.contains("android") && path.contains("-gcc"))
+            {
+                let ar = cc.get_archiver();
+                configure.env("AR", ar.get_program());
+                if ar.get_args().count() != 0 {
+                    // On some platforms (like emscripten on windows), the ar to use may not be a
+                    // single binary, but instead a multi-argument command like `cmd /c emar.bar`.
+                    // We can't convey that through `AR` alone, and so also need to set ARFLAGS.
+                    configure.env(
+                        "ARFLAGS",
+                        ar.get_args().collect::<Vec<_>>().join(OsStr::new(" ")),
+                    );
+                }
+
+                let ranlib = cc.get_ranlib();
+                // OpenSSL does not support RANLIBFLAGS. Jam the flags in RANLIB.
+                let mut args = vec![ranlib.get_program()];
+                args.extend(ranlib.get_args());
+                configure.env("RANLIB", args.join(OsStr::new(" ")));
             }
-            let ranlib = cc.get_ranlib();
-            // OpenSSL does not support RANLIBFLAGS. Jam the flags in RANLIB.
-            let mut args = vec![ranlib.get_program()];
-            args.extend(ranlib.get_args());
-            configure.env("RANLIB", args.join(OsStr::new(" ")));
 
             // Make sure we pass extra flags like `-ffunction-sections` and
             // other things like ARM codegen flags.


### PR DESCRIPTION
Fixes an issue with Android builds with ndk version 25 and up (and possibly 24)
Related issue: #188 
Related PR: #196 