### PR TITLE
Bump to 1.1.1w

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl-src"
-version = "111.27.0+1.1.1v"
+version = "111.28.0+1.1.1w"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
The last release on 1.1 branch (https://github.com/alexcrichton/openssl-src-rs/pull/208 for README update)