### PR TITLE
Disable WASI on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,9 +59,9 @@ jobs:
         - target: x86_64-pc-windows-gnu
           rust: stable
           os: ubuntu-latest
-        - target: wasm32-wasi
-          rust: stable
-          os: ubuntu-latest
+        # - target: wasm32-wasi
+        #   rust: stable
+        #   os: ubuntu-latest
         - target: i686-pc-windows-msvc
           rust: stable-i686-msvc
           os: windows-2019

--- a/ci/docker/wasm32-wasi/Dockerfile
+++ b/ci/docker/wasm32-wasi/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
   ca-certificates \
@@ -9,12 +9,11 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   xz-utils \
   libc6-dev
 
-# cargo-wasi setup (cargo-wasi depends on wasmtime to be present)
 RUN curl https://wasmtime.dev/install.sh -sSf | bash
 ENV PATH="$PATH:/root/.wasmtime/bin"
 
 # Install WASI-SDK
-ENV WASI_VERSION=14
+ENV WASI_VERSION=20
 ENV WASI_VERSION_FULL=${WASI_VERSION}.0
 RUN wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
 RUN tar xvf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz -C /root
@@ -23,6 +22,7 @@ RUN tar xvf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz -C /root
 ENV WASI_SDK_PATH=/root/wasi-sdk-${WASI_VERSION_FULL}
 ENV CC_wasm32-wasi="${WASI_SDK_PATH}/bin/clang --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot"
 ENV CARGO_TARGET_WASM32_WASI_LINKER="${WASI_SDK_PATH}/bin/clang"
+ENV CARGO_TARGET_WASM32_WASI_RUNNER=wasmtime
 
 ENV RUSTFLAGS=-Ctarget-feature=-crt-static
 

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -6,7 +6,6 @@ testcrate_dir="$(pwd)/testcrate"
 set -ex
 
 export CARGO_TARGET_AARCH64_APPLE_DARWIN_RUNNER=echo
-export CARGO_TARGET_WASM32_WASI_RUNNER=wasmtime
 
 cargo test --manifest-path "$testcrate_dir/Cargo.toml" --target $target -vvv
 cargo test --manifest-path "$testcrate_dir/Cargo.toml" --target $target -vvv --release

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,6 +505,8 @@ impl Build {
                     // -D_WASI_EMULATED_GETPID and link with -lwasi-emulated-getpid
                     // The link argument is output in the `Artifacts::print_cargo_metadata` method
                     "-D_WASI_EMULATED_GETPID",
+                    // WASI doesn't have chmod right now, so don't try to use it.
+                    "-DNO_CHMOD",
                 ]);
             }
 


### PR DESCRIPTION
This accidentally worked before but `crypto/uid.c` references nonexistent functions in the WASI SDK which no longer works with more recent versions of Clang in an updated WASI SDK. Currently WASI SDK I think has a bug when compiled against the latest version of LLVM (pulled in with updated rustc) which causes CI failures as well.

I've updated the configuration here to pull in a newer WASI SDK which exposes the failure to build with `crypto/uid.c`, but I unfortunately don't have time to track this further right now.