### PR TITLE
Fix MSVC Host Cross Compilation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,10 @@ impl Build {
         if host.contains("pc-windows-gnu") {
             configure.arg(&format!("--prefix={}", sanitize_sh(&install_dir)));
         } else if host.contains("pc-windows-msvc") {
-            configure.arg(&format!("--prefix={}", install_dir.to_str().unwrap().replace("\\", "/")));
+            configure.arg(&format!(
+                "--prefix={}",
+                install_dir.to_str().unwrap().replace("\\", "/")
+            ));
         } else {
             configure.arg(&format!("--prefix={}", install_dir.display()));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,10 @@ impl Build {
         if host.contains("pc-windows-gnu") {
             configure.arg(&format!("--prefix={}", sanitize_sh(&install_dir)));
         } else if host.contains("pc-windows-msvc") {
+            // On Windows, the prefix argument does not support \ path seperators
+            // when cross compiling.
+            // Always use / as a path seperator instead of \, since that works for both
+            // native and cross builds.
             configure.arg(&format!(
                 "--prefix={}",
                 install_dir.to_str().unwrap().replace("\\", "/")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,8 @@ impl Build {
         // Change the install directory to happen inside of the build directory.
         if host.contains("pc-windows-gnu") {
             configure.arg(&format!("--prefix={}", sanitize_sh(&install_dir)));
+        } else if host.contains("pc-windows-msvc") {
+            configure.arg(&format!("--prefix={}", install_dir.to_str().unwrap().replace("\\", "/")));
         } else {
             configure.arg(&format!("--prefix={}", install_dir.display()));
         }


### PR DESCRIPTION
Closes #118 

Without this patch, cross compilation on MSVC seems to directly embed backslashes from the prefix argument as various string constants in a C file via defines, like `ENGINESDIR`. This causes a build failure, as these backslashes get picked up as escape sequences.

Windows GNU targets are not affected by this issue, as they already do something similar to this patch within `sanitize_sh`.

I think this issue is caused by OpenSSL using the unix makefile template for cross-building to Linux, which I believe is not capable of escaping backslashes in the prefix argument. I believe that this is why a normal MSVC build works and why cross builds fail.

I have tested that this on Windows 11; this patch allows me to cross compile from `x86_64-pc-windows-msvc` to `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`.

