### PR TITLE
[111] loongarch64: Maps to linux-generic64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ impl Build {
             "i686-unknown-freebsd" => "BSD-x86-elf",
             "i686-unknown-linux-gnu" => "linux-elf",
             "i686-unknown-linux-musl" => "linux-elf",
-            "loongarch64-unknown-linux-gnu" => "linux64-loongarch64",
+            "loongarch64-unknown-linux-gnu" => "linux-generic64",
             "mips-unknown-linux-gnu" => "linux-mips32",
             "mips-unknown-linux-musl" => "linux-mips32",
             "mips64-unknown-linux-gnuabi64" => "linux64-mips64",


### PR DESCRIPTION
This patch remaps `loongarch64` to `linux-generic64` to disable vectors. (Guess it is not available when explicitly specified as `linux64-loongarch64`