### PR TITLE
Add ktls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ idea = []
 seed = []
 # Forces configuring Engine module support.
 force-engine = []
+# Enable kTLS support
+ktls = []
 
 [workspace]
 members = ['testcrate']

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,10 @@ impl Build {
             configure.arg("no-seed");
         }
 
+        if cfg!(feature = "ktls") {
+            configure.arg("enable-ktls");
+        }
+
         if target.contains("musl") {
             // Engine module fails to compile on musl (it needs linux/version.h
             // right now) but we don't actually need this most of the time.


### PR DESCRIPTION
This adds support for kTLS, but will not be enabled by default and will need to be set by the application with `SSL_OP_ENABLE_KTLS`.