### PR TITLE
Add support for x86_64-pc-windows-gnullvm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,6 +358,7 @@ impl Build {
             "x86_64-linux-android" => "linux-x86_64",
             "x86_64-linux" => "linux-x86_64",
             "x86_64-pc-windows-gnu" => "mingw64",
+            "x86_64-pc-windows-gnullvm" => "mingw64",
             "x86_64-pc-windows-msvc" => "VC-WIN64A",
             "x86_64-win7-windows-msvc" => "VC-WIN64A",
             "x86_64-unknown-freebsd" => "BSD-x86_64",


### PR DESCRIPTION
In my testing, this was enough to enable support for the [x86_64-pc-windows-gnullvm](https://doc.rust-lang.org/rustc/platform-support/pc-windows-gnullvm.html) target with [llvm-mingw](https://github.com/mstorsjo/llvm-mingw). Without this change, an error is raised because the target is unknown.