### PR TITLE
Surface the failing command's name from the build error dump

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ impl Build {
     }
 
     #[cfg(windows)]
+    #[track_caller]
     fn check_env_var(&self, var_name: &str) -> Option<bool> {
         env::var_os(var_name).map(|s| {
             if s == "1" {
@@ -631,6 +632,7 @@ impl Build {
         }
     }
 
+    #[track_caller]
     fn run_command(&self, mut command: Command, desc: &str) {
         println!("running {:?}", command);
         let status = command.status();
@@ -655,6 +657,7 @@ Error {}:
     }
 }
 
+#[track_caller]
 fn cp_r(src: &Path, dst: &Path) {
     for f in fs::read_dir(src).unwrap() {
         let f = f.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,11 +124,15 @@ impl Build {
         false
     }
 
-    #[track_caller]
+    /// Exits the process on failure. Use `try_build` to handle the error.
     pub fn build(&mut self) -> Artifacts {
         match self.try_build() {
             Ok(a) => a,
-            Err(e) => panic!("\n\n\n{e}\n\n\n"),
+            Err(e) => {
+                println!("cargo:warning=openssl-src: failed to build OpenSSL from source");
+                eprintln!("\n\n\n{e}\n\n\n");
+                std::process::exit(1);
+            }
         }
     }
 


### PR DESCRIPTION
Because [Cargo's formatting of build errors is very noisy](https://github.com/rust-lang/cargo/issues/10159) users struggle to understand what is causing the build to fail.

Here's a [recent case where the failure reason was simple, but the user could not see it](https://users.rust-lang.org/t/in-alpine-rust-can-not-link-ssl-library/117576/5) through all the noise.

----

```diff
    Compiling openssl-sys v0.9.103 (~/openssl-sys/openssl-sys)
+The following warnings were emitted during compilation:
+
+warning: openssl-sys@0.9.103: configuring OpenSSL build: Command 'perl' not found. Is perl installed?
+
 error: failed to run custom build command for `openssl-sys v0.9.103 (~/openssl-sys/openssl-sys)`
 note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.
 
 Caused by:
   process didn't exit successfully: `~/openssl-sys/target/debug/build/openssl-sys-60b6752181d583d2/build-script-main` (exit status: 101)
 
 [...]

   --- stderr
-   thread 'main' panicked at ~/openssl-src-rs/src/lib.rs:578:14:
+   thread 'main' panicked at ~/openssl-sys/build/find_vendored.rs:18:39:
 
 
 
   Error configuring OpenSSL build:
-      Command: cd "~/openssl-sys/target/debug/build/openssl-sys-8f90d3753aa6037e/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="ar" CC="cc" RANLIB="ranlib" "perl" "./Configure" "--prefix=~/openssl-sys/target/debug/build/openssl-sys-8f90d3753aa6037e/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-dso" "no-shared" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "darwin64-arm64-cc" "-nologo" "-MD" "-O2" "-Z7" "-Brepro" "-mmacosx-version-min=11.0"
-      Failed to execute: No such file or directory (os error 2)
+      Command 'perl' not found. Is perl installed?
+      Command failed: cd "~/openssl-sys/target/debug/build/openssl-sys-3ae48db4843d8fdf/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="ar" CC="cc" RANLIB="ranlib" "perl" "./Configure" "--prefix=~/openssl-sys/target/debug/build/openssl-sys-3ae48db4843d8fdf/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-shared" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "darwin64-arm64-cc" "-nologo" "-MD" "-O2" "-Z7" "-Brepro" "-mmacosx-version-min=11.0"
```

* Cleverness of the `Debug` impl of `Command` obscures the command name that has been run. This change prints the command name alone.
* NotFound error is handled with a dedicated message.
* Uses `cargo:warning` to also print the message above the stdout and stderr dumps.
