### PR TITLE
Set no-module to fix legacy provider

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ impl Build {
         configure
             // No shared objects, we just want static libraries
             .arg("no-shared")
+            .arg("no-module")
             // Should be off by default on OpenSSL 1.1.0, but let's be extra sure
             .arg("no-ssl3")
             // No need to build tests, we won't run them anyway


### PR DESCRIPTION
I'm honestly pretty confused as to how this was working previously - unless no-module is set, you'll end up with a legacy provider dynamic object that needs to exist in the openssldir: https://github.com/openssl/openssl/issues/17679

Tested here: https://github.com/sfackler/rust-openssl/pull/2331

Closes #257 