### PR TITLE
feat: expose configuration for SSLv3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ legacy = []
 # Enables compilation of some older algorithms: md2 (hash), rc5 (block cypher) and enabled use of
 # some weaker algorithms in SSL connections. These are generally not recommended for use.
 weak-crypto = []
+# Enables compilation of SSLv3, which is disabled by default.
+ssl3 = []
 # Enables compilation of the Camellia symmetric key block cypher. Since hardware acceleration for
 # it is not available on most systems, this is not as used as AES.
 camellia = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,8 +198,6 @@ impl Build {
             // No shared objects, we just want static libraries
             .arg("no-shared")
             .arg("no-module")
-            // Should be off by default on OpenSSL 1.1.0, but let's be extra sure
-            .arg("no-ssl3")
             // No need to build tests, we won't run them anyway
             .arg("no-tests")
             // Nothing related to zlib please
@@ -220,6 +218,13 @@ impl Build {
 
         if cfg!(not(feature = "legacy")) {
             configure.arg("no-legacy");
+        }
+
+        if cfg!(feature = "ssl3") {
+            configure.arg("enable-ssl3").arg("enable-ssl3-method");
+        } else {
+            // Should be off by default on OpenSSL 1.1.0, but let's be extra sure
+            configure.arg("no-ssl3");
         }
 
         if cfg!(feature = "weak-crypto") {


### PR DESCRIPTION
# Goal
Allow SSLv3 to be enabled for versions of openssl where it's disabled by default (specifically OpenSSL 3.5)

## How
Enable the underlying `ssl3` feature flag. In my own testing, the `ssl3-method` command was also necessary.

## Testing
I tested this locally with my application to confirm that SSLv3 could be successfully negotiated.