### PR TITLE
Exclude ci scripts from the published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,13 @@ exclude = [
 # The current upload size limit for *.crate files is 10MB. Therefore, exclude
 # some unused documentation to meet this constraint.
   'openssl/doc/man{3,5,7}',
+  '.github',
+  'ci',
+  '.gitignore',
+  '.gitmodules',
+  'openssl/.ctags.d/',
+  'openssl/.git-blame-ignore-revs',
+  'openssl/.gitattributes',
 ]
 
 [features]


### PR DESCRIPTION
During a dependency review I noticed that the openssl-src package includes ci scripts in the published crate on crates.io. These scripts are not required for building the crate and also they are not usfull outside of the CI setup you use.

This commit excludes CI scripts from the published package.

I also noticed that the bundled openssl source code seems to contain a lot of test code and data that might be meaningful to exclude. I've not done that as part of this PR as I would like to check if that's welcome first. If that's the case I'm happy to open a followup PR for that as well, although that likely also want's some sort of automated CI  checking (via `cargo package` ) to ensure everything that's required is actually included.