### PR TITLE
Add support for mips64-openwrt-linux-musl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,6 +357,7 @@ impl Build {
             "mips-unknown-linux-musl" => "linux-mips32",
             "mips64-unknown-linux-gnuabi64" => "linux64-mips64",
             "mips64-unknown-linux-muslabi64" => "linux64-mips64",
+            "mips64-openwrt-linux-musl" => "linux64-mips64",
             "mips64el-unknown-linux-gnuabi64" => "linux64-mips64",
             "mips64el-unknown-linux-muslabi64" => "linux64-mips64",
             "mipsel-unknown-linux-gnu" => "linux-mips32",


### PR DESCRIPTION
https://doc.rust-lang.org/beta/rustc/platform-support/mips64-openwrt-linux-musl.html

Closes #167 